### PR TITLE
feature: Add WithTable(...) and WithLogLevel(...) options

### DIFF
--- a/create.go
+++ b/create.go
@@ -56,7 +56,7 @@ func NonCreatableFields() []string {
 
 // Create a resource in the db with options: WithDebug, WithLookup,
 // WithReturnRowsAffected, OnConflict, WithBeforeWrite, WithAfterWrite,
-// WithVersion, and WithWhere.
+// WithVersion, WithTable, and WithWhere.
 //
 // OnConflict specifies alternative actions to take when an insert results in a
 // unique constraint or exclusion constraint error. If WithVersion is used with
@@ -147,7 +147,9 @@ func (rw *RW) Create(ctx context.Context, i interface{}, opt ...Option) error {
 	if opts.WithDebug {
 		db = db.Debug()
 	}
-
+	if opts.WithTable != "" {
+		db = db.Table(opts.WithTable)
+	}
 	if opts.WithBeforeWrite != nil {
 		if err := opts.WithBeforeWrite(i); err != nil {
 			return fmt.Errorf("%s: error before write: %w", op, err)
@@ -173,7 +175,7 @@ func (rw *RW) Create(ctx context.Context, i interface{}, opt ...Option) error {
 
 // CreateItems will create multiple items of the same type. Supported options:
 // WithDebug, WithBeforeWrite, WithAfterWrite, WithReturnRowsAffected,
-// OnConflict, WithVersion, and WithWhere. WithLookup is not a supported option.
+// OnConflict, WithVersion, WithTable, and WithWhere. WithLookup is not a supported option.
 func (rw *RW) CreateItems(ctx context.Context, createItems []interface{}, opt ...Option) error {
 	const op = "dbw.CreateItems"
 	if rw.underlying == nil {
@@ -213,6 +215,7 @@ func (rw *RW) CreateItems(ctx context.Context, createItems []interface{}, opt ..
 			WithDebug(opts.WithDebug),
 			WithVersion(opts.WithVersion),
 			WithWhere(opts.WithWhereClause, opts.WithWhereClauseArgs...),
+			WithTable(opts.WithTable),
 		); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -185,3 +185,22 @@ func TestDB_Close(t *testing.T) {
 		assert.Error(err)
 	})
 }
+
+func TestDB_LogLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level dbw.LogLevel
+	}{
+		{"default", dbw.Default},
+		{"silent", dbw.Silent},
+		{"error", dbw.Error},
+		{"warn", dbw.Warn},
+		{"info", dbw.Info},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _ := dbw.TestSetup(t)
+			db.LogLevel(tt.level)
+		})
+	}
+}

--- a/delete.go
+++ b/delete.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 )
 
-// Delete a resource in the db with options: WithWhere, WithDebug and
-// WithVersion. WithWhere and WithVersion allows specifying a additional
+// Delete a resource in the db with options: WithWhere, WithDebug, WithTable,
+// and WithVersion. WithWhere and WithVersion allows specifying a additional
 // constraints on the operation in addition to the PKs. Delete returns the
 // number of rows deleted and any errors.
 func (rw *RW) Delete(ctx context.Context, i interface{}, opt ...Option) (int, error) {
@@ -50,6 +50,9 @@ func (rw *RW) Delete(ctx context.Context, i interface{}, opt ...Option) (int, er
 	if opts.WithDebug {
 		db = db.Debug()
 	}
+	if opts.WithTable != "" {
+		db = db.Table(opts.WithTable)
+	}
 	db = db.Delete(i)
 	if db.Error != nil {
 		return noRowsAffected, fmt.Errorf("%s: %w", op, db.Error)
@@ -63,7 +66,8 @@ func (rw *RW) Delete(ctx context.Context, i interface{}, opt ...Option) (int, er
 	return rowsDeleted, nil
 }
 
-// DeleteItems will delete multiple items of the same type. Options supported: WithDebug
+// DeleteItems will delete multiple items of the same type. Options supported:
+// WithDebug, WithTable
 func (rw *RW) DeleteItems(ctx context.Context, deleteItems []interface{}, opt ...Option) (int, error) {
 	const op = "dbw.DeleteItems"
 	if rw.underlying == nil {
@@ -99,6 +103,7 @@ func (rw *RW) DeleteItems(ctx context.Context, deleteItems []interface{}, opt ..
 	for _, item := range deleteItems {
 		cnt, err := rw.Delete(ctx, item,
 			WithDebug(opts.WithDebug),
+			WithTable(opts.WithTable),
 		)
 		rowsDeleted += cnt
 		if err != nil {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -52,6 +52,25 @@ func TestDb_LookupBy(t *testing.T) {
 			want:    user,
 		},
 		{
+			name: "with-table",
+			rw:   testRw,
+			args: args{
+				resource: user,
+				opt:      []dbw.Option{dbw.WithTable(user.TableName())},
+			},
+			wantErr: false,
+			want:    user,
+		},
+		{
+			name: "with-table-fail",
+			rw:   testRw,
+			args: args{
+				resource: user,
+				opt:      []dbw.Option{dbw.WithTable("invalid-table-name")},
+			},
+			wantErr: true,
+		},
+		{
 			name: "compond",
 			rw:   testRw,
 			args: args{
@@ -123,7 +142,9 @@ func TestDb_LookupBy(t *testing.T) {
 			err := tt.rw.LookupBy(context.Background(), cp, tt.args.opt...)
 			if tt.wantErr {
 				require.Error(err)
-				assert.ErrorIs(err, tt.wantIsErr)
+				if tt.wantIsErr != nil {
+					assert.ErrorIs(err, tt.wantIsErr)
+				}
 				return
 			}
 			require.NoError(err)

--- a/option.go
+++ b/option.go
@@ -97,6 +97,10 @@ type Options struct {
 	// WithRowsAffected specifies an option for returning the rows affected
 	// and typically used with "bulk" write operations.
 	WithRowsAffected *int64
+
+	// WithTable specifies an option for setting a table name to use for the
+	// operation.
+	WithTable string
 }
 
 func getDefaultOptions() Options {
@@ -244,5 +248,13 @@ func WithOnConflict(onConflict *OnConflict) Option {
 func WithReturnRowsAffected(rowsAffected *int64) Option {
 	return func(o *Options) {
 		o.WithRowsAffected = rowsAffected
+	}
+}
+
+// WithTable specifies an option for setting a table name to use for the
+// operation.
+func WithTable(name string) Option {
+	return func(o *Options) {
+		o.WithTable = name
 	}
 }

--- a/option.go
+++ b/option.go
@@ -101,12 +101,15 @@ type Options struct {
 	// WithTable specifies an option for setting a table name to use for the
 	// operation.
 	WithTable string
+
+	withLogLevel LogLevel
 }
 
 func getDefaultOptions() Options {
 	return Options{
 		WithFieldMaskPaths: []string{},
 		WithNullPaths:      []string{},
+		withLogLevel:       Error,
 	}
 }
 
@@ -256,5 +259,12 @@ func WithReturnRowsAffected(rowsAffected *int64) Option {
 func WithTable(name string) Option {
 	return func(o *Options) {
 		o.WithTable = name
+	}
+}
+
+// WithLogLevel specifies an option for setting the log level
+func WithLogLevel(l LogLevel) Option {
+	return func(o *Options) {
+		o.withLogLevel = l
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -224,4 +224,17 @@ func Test_getOpts(t *testing.T) {
 		testOpts.WithMinOpenConnections = 1
 		assert.Equal(opts, testOpts)
 	})
+	t.Run("WithTable", func(t *testing.T) {
+		assert := assert.New(t)
+		// test default
+		opts := GetOpts()
+		testOpts := getDefaultOptions()
+		testOpts.WithTable = ""
+		assert.Equal(opts, testOpts)
+
+		opts = GetOpts(WithTable("tmp_table_name"))
+		testOpts = getDefaultOptions()
+		testOpts.WithTable = "tmp_table_name"
+		assert.Equal(opts, testOpts)
+	})
 }

--- a/option_test.go
+++ b/option_test.go
@@ -237,4 +237,17 @@ func Test_getOpts(t *testing.T) {
 		testOpts.WithTable = "tmp_table_name"
 		assert.Equal(opts, testOpts)
 	})
+	t.Run("WithLogLevel", func(t *testing.T) {
+		assert := assert.New(t)
+		// test default
+		opts := GetOpts()
+		testOpts := getDefaultOptions()
+		testOpts.withLogLevel = Error
+		assert.Equal(opts, testOpts)
+
+		opts = GetOpts(WithLogLevel(Warn))
+		testOpts = getDefaultOptions()
+		testOpts.withLogLevel = Warn
+		assert.Equal(opts, testOpts)
+	})
 }

--- a/reader.go
+++ b/reader.go
@@ -18,7 +18,7 @@ type Reader interface {
 	LookupByPublicId(ctx context.Context, resource ResourcePublicIder, opt ...Option) error
 
 	// LookupWhere will lookup and return the first resource using a where clause with parameters
-	LookupWhere(ctx context.Context, resource interface{}, where string, args ...interface{}) error
+	LookupWhere(ctx context.Context, resource interface{}, where string, args []interface{}, opt ...Option) error
 
 	// SearchWhere will search for all the resources it can find using a where
 	// clause with parameters. Supports the WithLimit option.  If

--- a/rw_test.go
+++ b/rw_test.go
@@ -76,15 +76,33 @@ func TestDb_LookupWhere(t *testing.T) {
 		assert.NotEmpty(user.PublicId)
 
 		var foundUser dbtest.TestUser
-		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", user.PublicId)
+		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{user.PublicId})
 		require.NoError(err)
 		assert.Equal(foundUser.PublicId, user.PublicId)
+	})
+	t.Run("with-table", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		w := dbw.New(conn)
+		user, err := dbtest.NewTestUser()
+		require.NoError(err)
+		user.Name = "foo-" + user.PublicId
+		err = w.Create(context.Background(), user, dbw.WithTable(user.TableName()))
+		require.NoError(err)
+		assert.NotEmpty(user.PublicId)
+
+		var foundUser dbtest.TestUser
+		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{user.PublicId}, dbw.WithTable(user.TableName()))
+		require.NoError(err)
+		assert.Equal(foundUser.PublicId, user.PublicId)
+
+		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{user.PublicId}, dbw.WithTable("invalid-table-name"))
+		require.Error(err)
 	})
 	t.Run("tx-nil,", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)
 		w := dbw.RW{}
 		var foundUser dbtest.TestUser
-		err := w.LookupWhere(context.Background(), &foundUser, "public_id = ?", 1)
+		err := w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{1})
 		require.Error(err)
 		assert.Equal("dbw.LookupWhere: missing underlying db: invalid parameter", err.Error())
 	})
@@ -95,7 +113,7 @@ func TestDb_LookupWhere(t *testing.T) {
 		require.NoError(err)
 
 		var foundUser dbtest.TestUser
-		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", id)
+		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{id})
 		require.Error(err)
 		assert.ErrorIs(err, dbw.ErrRecordNotFound)
 	})
@@ -106,7 +124,7 @@ func TestDb_LookupWhere(t *testing.T) {
 		require.NoError(err)
 
 		var foundUser dbtest.TestUser
-		err = w.LookupWhere(context.Background(), &foundUser, "? = ?", id)
+		err = w.LookupWhere(context.Background(), &foundUser, "? = ?", []interface{}{id})
 		require.Error(err)
 	})
 	t.Run("not-ptr", func(t *testing.T) {
@@ -116,7 +134,7 @@ func TestDb_LookupWhere(t *testing.T) {
 		require.NoError(err)
 
 		var foundUser dbtest.TestUser
-		err = w.LookupWhere(context.Background(), foundUser, "public_id = ?", id)
+		err = w.LookupWhere(context.Background(), foundUser, "public_id = ?", []interface{}{id})
 		require.Error(err)
 	})
 	t.Run("hooks", func(t *testing.T) {
@@ -130,7 +148,7 @@ func TestDb_LookupWhere(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				assert, require := assert.New(t), require.New(t)
 				w := dbw.New(conn)
-				err := w.LookupWhere(context.Background(), tt.resource, "public_id = ?", "1")
+				err := w.LookupWhere(context.Background(), tt.resource, "public_id = ?", []interface{}{"1"})
 				require.Error(err)
 				assert.ErrorIs(err, dbw.ErrInvalidParameter)
 				assert.Contains(err.Error(), "gorm callback/hooks are not supported")
@@ -203,6 +221,29 @@ func TestDb_SearchWhere(t *testing.T) {
 			},
 			wantCnt: 1,
 			wantErr: false,
+		},
+		{
+			name:      "with-table",
+			rw:        testRw,
+			createCnt: 1,
+			args: args{
+				where: "public_id = ?",
+				arg:   []interface{}{knownUser.PublicId},
+				opt:   []dbw.Option{dbw.WithLimit(3), dbw.WithTable(knownUser.TableName())},
+			},
+			wantCnt: 1,
+			wantErr: false,
+		},
+		{
+			name:      "with-table-fail",
+			rw:        testRw,
+			createCnt: 1,
+			args: args{
+				where: "public_id = ?",
+				arg:   []interface{}{knownUser.PublicId},
+				opt:   []dbw.Option{dbw.WithLimit(3), dbw.WithTable("invalid-table-name")},
+			},
+			wantErr: true,
 		},
 		{
 			name:      "no args",

--- a/rw_test.go
+++ b/rw_test.go
@@ -76,7 +76,7 @@ func TestDb_LookupWhere(t *testing.T) {
 		assert.NotEmpty(user.PublicId)
 
 		var foundUser dbtest.TestUser
-		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ?", []interface{}{user.PublicId})
+		err = w.LookupWhere(context.Background(), &foundUser, "public_id = ? and 1 = ?", []interface{}{user.PublicId, 1})
 		require.NoError(err)
 		assert.Equal(foundUser.PublicId, user.PublicId)
 	})

--- a/update.go
+++ b/update.go
@@ -46,14 +46,14 @@ func NonUpdatableFields() []string {
 // returned the caller must decide what to do with the transaction, which almost
 // always should be to rollback.  Update returns the number of rows updated.
 //
-// Supported options: WithBeforeWrite, WithAfterWrite, WithWhere, WithDebug, and
-// WithVersion. If WithVersion is used, then the update will include the version
-// number in the update where clause, which basically makes the update use
-// optimistic locking and the update will only succeed if the existing rows
-// version matches the WithVersion option. Zero is not a valid value for the
-// WithVersion option and will return an error. WithWhere allows specifying an
-// additional constraint on the operation in addition to the PKs. WithDebug will
-// turn on debugging for the update call.
+// Supported options: WithBeforeWrite, WithAfterWrite, WithWhere, WithDebug,
+// WithTable and WithVersion. If WithVersion is used, then the update will
+// include the version number in the update where clause, which basically makes
+// the update use optimistic locking and the update will only succeed if the
+// existing rows version matches the WithVersion option. Zero is not a valid
+// value for the WithVersion option and will return an error. WithWhere allows
+// specifying an additional constraint on the operation in addition to the PKs.
+// WithDebug will turn on debugging for the update call.
 func (rw *RW) Update(ctx context.Context, i interface{}, fieldMaskPaths []string, setToNullPaths []string, opt ...Option) (int, error) {
 	const op = "dbw.Update"
 	if rw.underlying == nil {
@@ -123,6 +123,9 @@ func (rw *RW) Update(ctx context.Context, i interface{}, fieldMaskPaths []string
 	underlying := rw.underlying.wrapped.Model(i)
 	if opts.WithDebug {
 		underlying = underlying.Debug()
+	}
+	if opts.WithTable != "" {
+		underlying = underlying.Table(opts.WithTable)
 	}
 	switch {
 	case opts.WithVersion != nil || opts.WithWhereClause != "":


### PR DESCRIPTION
This allows a table to be optionally specified for the database
operation. This change also required changing the signature for RW.LookupWhere
so it supported taking options

The PR also support setting the `DB` log level properly.